### PR TITLE
Prevent FileNotFoundException when known_hosts doesn't exists fix #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ autodoc/**
 doc/**
 .lein-*
 .nrepl-*
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: lein
 before_script:
 - ssh-keygen -N "" -f ~/.ssh/id_rsa
 - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
@@ -11,9 +11,9 @@ before_script:
 - echo "clj-ssh" > pp
 - chmod +x pp
 - setsid ssh-add ~/.ssh/clj_ssh_pp < pp
-script: lein2 test
+script: lein test
 after_success:
-- lein2 pallet-release push
+- lein pallet-release push
 env:
   global:
     secure: eOBqYhJhOJMtRiMKs9ZgG4pEHFy7YqiBZ5NUEWUYD6qav6sMRHqqR5F04NRI37SmnIupzeTChqfRgX0DOwHeTl4u+QJnwRDH2z3avu75FbtZWgiGrxzE39SESpVj/zsyDrEUzT7ZiMayXKyNa3ObiJ8vBUFT7x/OZyRp/1rJxHU=

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,6 @@
                  [com.jcraft/jsch.agentproxy.pageant ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.core ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.jsch ~agentproxy-version]
-                 [com.jcraft/jsch "0.1.53"]]
+                 [com.jcraft/jsch "0.1.54"]]
   :jvm-opts ["-Djava.awt.headless=true"]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.4.0"]]}})


### PR DESCRIPTION
com.jcraft/jsch `0.1.53` throw an exception when `root/.ssh/known_hosts` is not found. Updating to version `0.1.54` fix this issue.