### PR TITLE
Update of jsch version and generate-keypair API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 # clj-ssh
 
-SSH in clojure.  Uses jsch.
+SSH in clojure.  Uses jsch. 
+(See section RSA Private Key format if using openssl generated keys)
 
 ## Usage
 
@@ -144,6 +145,42 @@ works with both a `jump-session` session and a single host session.
 
 [Annotated source](http:/hugoduncan.github.com/clj-ssh/0.5/annotated/uberdoc.html).
 [API](http:/hugoduncan.github.com/clj-ssh/0.5/api/index.html).
+
+## RSA Private Key Format and clj-ssh
+
+There have been changes to the header of RSA Private Keys.  With the upgrade of 
+com.jcraft/jsch to "0.1.55", the older openssh headers work with ssh will throw 
+an authentication failure.
+
+Older format
+```
+-----BEGIN OPENSSH PRIVATE KEY-----`
+```
+
+New RSA format
+```
+-----BEGIN RSA PRIVATE KEY-----
+```
+
+Old private keys can be easily converted to the new format, through the use of
+ssh-keygen's passphrase changing command.  This will change the file in place.
+```
+ssh-keygen -p -f privateKeyFile -m pem -P passphrase -N passphrase
+``` 
+The -m flag will force the file to pem format, fixing the header.  
+The -P (for old passphrase) and -N (new passphrase) can be ommitted to generate
+an interactive query instead.
+(enter "" at either -P or -N to identify no passphrase)
+
+### Note: clj-ssh key generation
+clj-ssh does have the ability to generate the public / private key pairs for both
+RSA and DSA (found in clj-ssh.ssh/generate-keypair).
+
+Unlike ssh-keygen, the RSA passphrase on the private key will be limited to   
+DES-EDE3-CBC DEK format to encrypt/decrypt the passphrase if created within clj-ssh.
+ssh-keygen will likely use what is standard in your operating system's crypto suite, 
+(e.g. AES-128-CBC) 
+
 
 ## FAQ
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,17 @@
+## 0.5.16
+
+- Moved jsch to version 0.1.55 
+
+- Moved clojure tools.logging to 1.2.4
+
+- Moved logback-classic to 1.4.7
+
+- Changed ssh/generate-keypair to now match jsch API 
+  (and remove setPassphrase method which is listed as depricated)
+
+- Included section in readme.md regarding RSA header issues and 
+  compatibilities
+
 ## 0.5.14
 
 - Remove println from scp code

--- a/profiles.clj
+++ b/profiles.clj
@@ -14,7 +14,7 @@
  :clojure-1.10.2 {:dependencies [[org.clojure/clojure "1.10.2"]]}
  :clojure-1.10.3 {:dependencies [[org.clojure/clojure "1.10.3"]]}
  :clojure-1.11.0 {:dependencies [[org.clojure/clojure "1.11.0"]]}
- :clojure-1.11.1 {:dependencies [[org.clojure/clojure "1.11.01"]]}
+ :clojure-1.11.1 {:dependencies [[org.clojure/clojure "1.11.1"]]}
  
  
  }

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,12 +1,20 @@
 {:dev
- {:dependencies [[ch.qos.logback/logback-classic "1.0.0"]]
+ {:dependencies [[ch.qos.logback/logback-classic "1.4.7"]]
   :aliases {"test" ["with-profile"
-                    "clojure-1.4.0:clojure-1.5.1:clojure-1.6.0:clojure-1.7.0:clojure-1.8.0"
+                    "clojure-1.4.0:clojure-1.5.1:clojure-1.6.0:clojure-1.7.0:clojure-1.8.0:clojure-1.9.0:clojure-1.10.0:clojure-1.10.1:clojure-1.10.2:clojure-1.10.3:clojure-1.11.0:clojure-1.11.1"
                     "test"]}}
- :clojure-1.2.1 {:dependencies [[org.clojure/clojure "1.2.1"]]}
- :clojure-1.3.0 {:dependencies [[org.clojure/clojure "1.3.0"]]}
  :clojure-1.4.0 {:dependencies [[org.clojure/clojure "1.4.0"]]}
  :clojure-1.5.1 {:dependencies [[org.clojure/clojure "1.5.1"]]}
  :clojure-1.6.0 {:dependencies [[org.clojure/clojure "1.6.0"]]}
  :clojure-1.7.0 {:dependencies [[org.clojure/clojure "1.7.0"]]}
- :clojure-1.8.0 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
+ :clojure-1.8.0 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+ :clojure-1.9.0  {:dependencies [[org.clojure/clojure "1.9.0"]]} 
+ :clojure-1.10.0 {:dependencies [[org.clojure/clojure "1.10.0"]]}
+ :clojure-1.10.1 {:dependencies [[org.clojure/clojure "1.10.1"]]}
+ :clojure-1.10.2 {:dependencies [[org.clojure/clojure "1.10.2"]]}
+ :clojure-1.10.3 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+ :clojure-1.11.0 {:dependencies [[org.clojure/clojure "1.11.0"]]}
+ :clojure-1.11.1 {:dependencies [[org.clojure/clojure "1.11.01"]]}
+ 
+ 
+ }

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
 (def agentproxy-version "0.0.9")
 
-(defproject clj-commons/clj-ssh "0.5.15-SNAPSHOT"
+(defproject clj-commons/clj-ssh "0.5.16-SNAPSHOT"
   :description "Library for using SSH from clojure."
   :url "https://github.com/clj-commons/clj-ssh"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/tools.logging "0.2.6"
+  :dependencies [[org.clojure/tools.logging "1.2.4"
                   :exclusions [org.clojure/clojure]]
                  [com.jcraft/jsch.agentproxy.usocket-jna ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.usocket-nc ~agentproxy-version]
@@ -13,6 +13,6 @@
                  [com.jcraft/jsch.agentproxy.pageant ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.core ~agentproxy-version]
                  [com.jcraft/jsch.agentproxy.jsch ~agentproxy-version]
-                 [com.jcraft/jsch "0.1.53"]]
+                 [com.jcraft/jsch "0.1.55"]]
   :jvm-opts ["-Djava.awt.headless=true"]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]]}})


### PR DESCRIPTION
Good day,
I was looking for a package specifically to handle ssh from clojure and identified that maven was reporting CVE's with some of the versions or the java code used in your project.  As newer versions were available, I've dropped in the new jsch version and fixed code that broke in the process.  

I've updated the versions and made some changes to ensure the tests now pass.  
While learning the code, I also identified that there were issues with the ssh/generate-keypair function that I also moved forward to update, as well as an issue with RSA key compatibilities (depending on how they were generated, e.g. ssh-keygen. ) Tests were not covering writing out the reading the certs.  I did not presume to re-write the test as I'm unsure how / or if, you would like to proceed.

I've included documentation in the readme to describe the RSA and private key issues that an implementer would also need to be aware of. 

I've noticed that there might also be some issues with scp recursion that I might look to fix in the future if you are interested  (I'm only getting local recursion and not remote, though I'm currently considering the value in fix it)

As this is my first pull request, let me know if this is the preferred level of detail for this project.  (I've also updated the release notes describing the changes should this pull request be approved.)

Jason Brault <contact@combinedarms.ca>
