### PR TITLE
Updates clj-ssh to latest JSch 0.2.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,13 @@
-(def agentproxy-version "0.0.9")
-
-(defproject clj-commons/clj-ssh "0.5.16-SNAPSHOT"
+(defproject clj-commons/clj-ssh "0.6.0-SNAPSHOT"
   :description "Library for using SSH from clojure."
   :url "https://github.com/clj-commons/clj-ssh"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/tools.logging "1.2.4"
                   :exclusions [org.clojure/clojure]]
-                 [com.jcraft/jsch.agentproxy.usocket-jna ~agentproxy-version]
-                 [com.jcraft/jsch.agentproxy.usocket-nc ~agentproxy-version]
-                 [com.jcraft/jsch.agentproxy.sshagent ~agentproxy-version]
-                 [com.jcraft/jsch.agentproxy.pageant ~agentproxy-version]
-                 [com.jcraft/jsch.agentproxy.core ~agentproxy-version]
-                 [com.jcraft/jsch.agentproxy.jsch ~agentproxy-version]
-                 [com.jcraft/jsch "0.1.55"]]
+                 [com.github.mwiede/jsch "0.2.9"]
+                 [net.java.dev.jna/jna "5.13.0"]
+                 [com.kohlschutter.junixsocket/junixsocket-core "2.6.2" :extension "pom"]]
   :jvm-opts ["-Djava.awt.headless=true"]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]]}})
+

--- a/src/clj_ssh/agent.clj
+++ b/src/clj_ssh/agent.clj
@@ -3,31 +3,29 @@
   (:require
    [clojure.tools.logging :as logging])
   (:import
-   com.jcraft.jsch.JSch
-   [com.jcraft.jsch.agentproxy
-    AgentProxyException Connector RemoteIdentityRepository]
-   [com.jcraft.jsch.agentproxy.connector
-    PageantConnector SSHAgentConnector]
-   com.jcraft.jsch.agentproxy.usocket.JNAUSocketFactory))
+   [com.jcraft.jsch
+    JSch AgentProxyException AgentIdentityRepository
+    PageantConnector SSHAgentConnector JUnixSocketFactory]))
 
 (defn sock-agent-connector
   []
-  (when (SSHAgentConnector/isConnectorAvailable)
-    (try
-      (let [usf (JNAUSocketFactory.)]
-        (SSHAgentConnector. usf))
-      (catch AgentProxyException e
-        (logging/warnf
-         e "Failed to load JNA connector, although SSH_AUTH_SOCK is set")))))
+  (try
+    (let [con (SSHAgentConnector.)]
+      (when (.isAvailable con)
+        con))
+    (catch AgentProxyException e
+      (logging/warnf
+       e "Failed to load JNA connector, although SSH_AUTH_SOCK is set"))))
 
 (defn pageant-connector
   []
-  (when (PageantConnector/isConnectorAvailable)
-    (try
-      (PageantConnector.)
-      (catch AgentProxyException e
-        (logging/warn
-         e "Failed to load Pageant connector, although running on windows")))))
+  (try
+    (let [con (PageantConnector.)]
+      (when (.isAvailable con)
+        con))
+    (catch AgentProxyException e
+      (logging/warn
+       e "Failed to load Pageant connector, although running on windows"))))
 
 (defn connect
   "Connect the specified jsch object to the system ssh-agent."
@@ -35,4 +33,4 @@
   (when-let [connector (or (sock-agent-connector) (pageant-connector))]
     (doto jsch
       ;(.setConfig "PreferredAuthentications" "publickey")
-      (.setIdentityRepository (RemoteIdentityRepository. connector)))))
+      (.setIdentityRepository (AgentIdentityRepository. connector)))))

--- a/src/clj_ssh/ssh.clj
+++ b/src/clj_ssh/ssh.clj
@@ -236,6 +236,7 @@
   (^boolean setPassphrase [_ ^bytes passphrase] (.. kpair (decrypt passphrase)))
   (getPublicKeyBlob [_] (.. kpair getPublicKeyBlob))
   (^bytes getSignature [_ ^bytes data] (.. kpair (getSignature data)))
+  (^bytes getSignature [_ ^bytes data ^String alg] (.. kpair (getSignature data alg)))
   (getAlgName [_]
     (String. (reflect/call-method KeyPair 'getKeyTypeName [] kpair)))
   (getName [_] identity)


### PR DESCRIPTION
Updates agent code for package and class name changes done in com.github.mwiede's JSch fork.
Removes unncessary agentproxy dependencies that have been merged in that project and adds more modern jna and junixsocket libs. Bumps version to make it explicit this newer dependency.

Addresses https://github.com/clj-commons/clj-ssh/issues/62
Supersedes https://github.com/clj-commons/clj-ssh/pull/64