### PR TITLE
Fixes CircleCI tests run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,10 @@
-# Clojure CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-clojure/ for more details
-#
-version: 2
+version: 2.1
 jobs:
   build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/clojure:lein-2.7.1
+    machine:
+      image: ubuntu-2004:2023.07.1
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+    resource_class: medium
 
     working_directory: ~/repo
 
@@ -31,22 +23,30 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: lein deps
+      - run:
+          name: Setup environment
+          command: sudo apt-get update && sudo apt-get install -y openjdk-8-jdk leiningen
+
+      - run:
+          name: Fetch project dependencies
+          command: lein deps
 
       - save_cache:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "project.clj" }}
+
       - run:
+          name: Setup tests
           command: |
-             yes y | ssh-keygen -N "" -f ~/.ssh/id_rsa >/dev/null
+             [[ -f ~/.ssh/id_rsa ]] || ssh-keygen -N "" -f ~/.ssh/id_rsa
              cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
              ssh-keygen -f ~/.ssh/clj_ssh -t rsa -C "key for test clj-ssh" -N ""
              ssh-keygen -f ~/.ssh/clj_ssh_pp -t rsa -C "key for test clj-ssh" -N "clj-ssh"
              echo "from=\"127.0.0.1,localhost,0.0.0.0\" $(cat ~/.ssh/clj_ssh.pub)" >> ~/.ssh/authorized_keys
              echo "from=\"127.0.0.1,localhost,0.0.0.0\" $(cat ~/.ssh/clj_ssh_pp.pub)" >> ~/.ssh/authorized_keys
              eval $(ssh-agent)
-             cat << EOF > pp
+             cat \<< EOF > pp
              #!/bin/sh
              echo "clj-ssh"
              EOF
@@ -54,5 +54,7 @@ jobs:
              export SSH_ASKPASS=./pp
              export DISPLAY=1
              setsid ssh-add ~/.ssh/clj_ssh_pp < /dev/null >/dev/null 2>&1
-      # run tests!
-      - run: lein test
+
+      - run:
+          name: Run tests
+          command: lein test


### PR DESCRIPTION
Fixes CircleCI tests run by:
 - replacing Docker Image with VM which has a running OpenSSH server required to run tests
 - skip creating id_rsa if it exists to prevent using `yes` which causes CircleCI to fail allowing to use existent key.  - 

Additionally, upgraded CircleCI config to latest 2.1 version and added friendly names to the CI steps.

--
When attempting to run tests in CircleCI we observed several issues.

First, it seems CircleCI fails when we try using `yes` to pipe an yes-answer to a command (see https://discuss.circleci.com/t/failed-build-exit-code-141/26335). This `yes` command was needed to be able to replace `id_rsa` key when it exists. To workaround this issue, I've modified the logic to only generate`id_rsa` key when it does not exist - and hence not requiring a confirmation. Note that, attempting to remove `~/.ssh` and allow the existent logic to generate all keys also causes failures.

Second, when running tests in Docker, the container does not provide an SSH server where the tests can connect to - so all tests fail. I've made an attempt to install the OpenSSH server in the original docker image but was faced with the issue that APT servers for Debian 9 changed (too old version) which further required me to modify APT servers. Instead, I've done an attempt to use more modern convenient images as described in https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034 . I've made some progress by installing and starting OpenSSH server but there were several test failures. Also, the approach was a bit cumbersome because everytime the image started I would install OpenSSH (not benefitting from Docker image builds) and having to start the OpenSSH server before running the tests. Creating a custom Docker image forces us to publish it and make it public - create a dependency to an external registry and creating a image that is only specific for these tests. Instead, I've decided to use an "old-fashioned" VM linux and that made the trick.
As part of that change, I've used Ubuntu 20.04 (Focal Fossa) LTS as it's OpenSSL version already deprecates RSA keys schemas but it's not as modern as in later Ubuntu 22.04.

Non-necessary changes:
 * Upgrading config version to `2.1`, but why not ensure we're at the latest version of what CircleCI updates
 * Adding prettier labels to steps.
 * Removing file header comments which point to URL that doesn't exist.

