### PR TITLE
Run deploy on release tags only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ workflows:
           requires:
             - build
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /Release-.*/
           context:


### PR DESCRIPTION
Modifies pipeline definition to skip running deploy on all branches (preventing PR validation to fail), running only on `Release-*` tags.