### PR TITLE
Update badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-[![Clojars Project](https://img.shields.io/clojars/v/clj-commons/clj-ssh.svg)](https://clojars.org/clj-commons/clj-ssh)
-[![cljdoc badge](https://cljdoc.org/badge/clj-commons/clj-ssh)](https://cljdoc.org/d/clj-commons/clj-ssh/CURRENT)
+[![Clojars Project](https://img.shields.io/clojars/v/org.clj-commons/clj-ssh.svg)](https://clojars.org/org.clj-commons/clj-ssh)
+[![cljdoc badge](https://cljdoc.org/badge/org.clj-commons/clj-ssh)](https://cljdoc.org/d/org.clj-commons/clj-ssh/CURRENT)
 [![CircleCI](https://circleci.com/gh/clj-commons/clj-ssh.svg?style=svg)](https://circleci.com/gh/clj-commons/clj-ssh)
 
 # clj-ssh


### PR DESCRIPTION
The current badges point to an old repo which caused much debugging and confusion.